### PR TITLE
Add class method human_attribute_value

### DIFF
--- a/lib/human_attribute/active_record/base.rb
+++ b/lib/human_attribute/active_record/base.rb
@@ -1,6 +1,16 @@
 module ActiveRecord
   class Base
 
+    # en.activerecord.attribute_values.class_name.attribute_name
+    # Example I18n lookup: en.activerecord.attribute_values.user.state
+    def self.human_attribute_value(attribute_name, value)
+      if value.present?
+        I18n.t(value, :scope => "activerecord.attribute_values.#{self.name.underscore}.#{attribute_name}")
+      else
+        value
+      end
+    end
+
     # Looks in en.activerecord.attributes.class.attribute_name
     # Example I18n lookup: en.activerecord.attributes.user.state
     def human_name(attribute_name)
@@ -11,12 +21,7 @@ module ActiveRecord
     # Example I18n lookup: en.activerecord.attribute_values.user.state
     def human_value(attribute_name)
       value = send(attribute_name)
-      if value.present?
-        I18n.t(value, :scope => "activerecord.attribute_values.#{self.class.name.underscore}.#{attribute_name}")
-      else
-        value
-      end
+      self.class.human_attribute_value attribute_name, value
     end
-
   end
 end

--- a/lib/human_attribute/version.rb
+++ b/lib/human_attribute/version.rb
@@ -1,3 +1,3 @@
 module HumanAttribute
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Add class method to ActiveRecord::Base named `human_attribute_value(attribute_name, value)`

Helpful in combination with options_for_select and other gems like active_enum + simple_form.

```
class SimpleForm::EnumInput < SimpleForm::Inputs::CollectionRadioButtonsInput
  def collection
    @column.limit.map { |v| [object.class.human_attribute_value(@attribute_name, v), v] }
  end

  def input_type
    :radio_buttons
  end
end
class EnumInput < SimpleForm::EnumInput; end
```

You can then add enum radio buttons to your form just like that:

```
= f.input :payment_type
```

Without simple form you could use it inside options_for_select like this:

```
= select_tag :status, options_for_select(Order.columns_hash['payment_type'].limit.map{|v|[Order.human_attribute_value(:payment_type, v), v]})
```