### PR TITLE
allow booleans to be translated into human readable attributes

### DIFF
--- a/lib/human_attribute/active_record/base.rb
+++ b/lib/human_attribute/active_record/base.rb
@@ -4,11 +4,8 @@ module ActiveRecord
     # en.activerecord.attribute_values.class_name.attribute_name
     # Example I18n lookup: en.activerecord.attribute_values.user.state
     def self.human_attribute_value(attribute_name, value)
-      if value.present?
-        I18n.t(value, :scope => "activerecord.attribute_values.#{self.name.underscore}.#{attribute_name}")
-      else
-        value
-      end
+      return nil if value.nil?
+      I18n.t(value, :scope => "activerecord.attribute_values.#{self.name.underscore}.#{attribute_name}")
     end
 
     # Looks in en.activerecord.attributes.class.attribute_name


### PR DESCRIPTION
If the attribute is a boolean, human_value returns only in the case of true the correct value.
I fixed the code, so that `false` also will return a value